### PR TITLE
fix region limitation to us-west-2

### DIFF
--- a/aws/s3.go
+++ b/aws/s3.go
@@ -28,9 +28,7 @@ func CreateS3Bucket(client S3Client, bucketName *string, accountId *string) *str
 
 	_, err := client.CreateBucket(context.TODO(), &s3.CreateBucketInput{
 		Bucket: bucketName,
-		CreateBucketConfiguration: &types.CreateBucketConfiguration{
-			LocationConstraint: types.BucketLocationConstraintUsWest2,
-		},
+		CreateBucketConfiguration: &types.CreateBucketConfiguration{},
 	})
 	if err != nil {
 		var bne *types.BucketAlreadyOwnedByYou


### PR DESCRIPTION

*Description of changes:*
removed location constrained when creating an S3 bucket and added second s3 us-west-2 client to download agent binary.
This allows to use the cli with the region specific tag


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
