### PR TITLE
Fixed hardcoded root cert certificate path in agent.W

### DIFF
--- a/aws/iam.go
+++ b/aws/iam.go
@@ -278,6 +278,8 @@ func CreateDeviceFleetPolicy(client IamClient, cliArgs *cli.CliArgs) *types.Poli
 		}
 
 		log.Fatalf("Failed to get policy with name %s. Encountered error %s\n", policyName, err)
+	} else {
+		log.Println("Policy already exists in the account!")
 	}
 
 	return getPolicyOutput.Policy

--- a/cli/cli_args.go
+++ b/cli/cli_args.go
@@ -136,7 +136,7 @@ func ParseArgs(cliArgs *CliArgs) {
 	cliArgs.TargetPlatform.Validate()
 
 	cliArgs.Account = *accountId
-	cliArgs.Region = *region
+	cliArgs.Region = strings.ToLower(*region)
 	cliArgs.AgentDirectory = *agentDirectory
 
 	if *iotThingType == "" {

--- a/common/utils.go
+++ b/common/utils.go
@@ -216,8 +216,8 @@ func untar(agentFile *string, dest *string) {
 
 func DownloadSigningRootCert(client *s3.Client, cliArgs *cli.CliArgs) {
 	certBucket := "sagemaker-edge-release-store-us-west-2-linux-x64"
-	certKey := "Certificates/us-west-2/us-west-2.pem"
-	certPath := filepath.Join(cliArgs.AgentDirectory, "certificates", "us-west-2.pem")
+	certKey := fmt.Sprintf("Certificates/%s/%s.pem", cliArgs.Region, cliArgs.Region)
+	certPath := filepath.Join(cliArgs.AgentDirectory, "certificates", fmt.Sprintf("%s.pem", cliArgs.Region))
 	aws.DownloadFileFromS3ToPath(client, &certBucket, &certKey, &certPath)
 	os.Chmod(certPath, 0400)
 }


### PR DESCRIPTION
*Description of changes:*

The hardcoded cert path only downloads the `us-west-2` certificate which fails to validate the models signed in a different region. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
